### PR TITLE
Require sentry-ruby in the gem lib

### DIFF
--- a/.rubocop_rules.yml
+++ b/.rubocop_rules.yml
@@ -1,5 +1,5 @@
 ---
-RuboCop-version: 1.65.0 (using Parser 3.3.4.0, rubocop-ast 1.31.3, running on ruby
+RuboCop-version: 1.65.0 (using Parser 3.3.4.0, rubocop-ast 1.32.0, running on ruby
   3.2.4)
 Bundler/DuplicatedGem:
   Severity: warning

--- a/.rubocop_rules.yml
+++ b/.rubocop_rules.yml
@@ -1,6 +1,6 @@
 ---
 RuboCop-version: 1.65.0 (using Parser 3.3.4.0, rubocop-ast 1.32.0, running on ruby
-  3.2.4)
+  3.2.5)
 Bundler/DuplicatedGem:
   Severity: warning
   VersionAdded: '0.46'

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,6 @@ group :development, :test do
   gem 'gl_lint'
   gem 'rspec'
   gem 'rspec_junit_formatter'
-  gem 'rubocop-rails' # Remove once gl_lint is updated to 0.4.x (it's required)
   gem 'rubocop', '1.65.0' # Lock so that .rubocop_rules.yml doesn't change
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ group :development, :test do
   gem 'rspec'
   gem 'rspec_junit_formatter'
   gem 'rubocop-rails' # Remove once gl_lint is updated to 0.4.x (it's required)
-  gem 'rubocop', '1.65.0'
+  gem 'rubocop', '1.65.0' # Lock so that .rubocop_rules.yml doesn't change
 end
 
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ group :development, :test do
   gem 'gl_lint'
   gem 'rspec'
   gem 'rspec_junit_formatter'
-  gem 'rubocop', '1.65.0' # Lock so that .rubocop_rules.yml doesn't change
+  gem 'rubocop', '1.65.0' # Lock to reduce churn in .rubocop_rules.yml
 end
 
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ group :development, :test do
   gem 'rspec'
   gem 'rspec_junit_formatter'
   gem 'rubocop-rails' # Remove once gl_lint is updated to 0.4.x (it's required)
+  gem 'rubocop', '1.65.0'
 end
 
 gemspec

--- a/gl_exception_notifier.gemspec
+++ b/gl_exception_notifier.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'gl_exception_notifier'
-  s.version = '1.0.1'
+  s.version = '1.0.2'
   s.summary = "A wrapper for GiveLively's exception notifier"
   s.authors = ['Give Lively', 'Tim Lawrenz', 'Joe Anzalone', 'Dave Urban']
   s.description = "To avoid having to update exception notifiers in all the different repositories,
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 3.1'
 
   s.email = 'tim@givelively.org'
-  s.files = ['lib/gl_exception_notifier.rb']
+  s.files = %w[gl_exception_notifier.gemspec README.md LICENSE] + `git ls-files | grep -E '^(lib)'`.split("\n")
   s.require_paths = ['lib']
   s.homepage = 'https://github.com/givelively/gl_exception_notifier/'
   s.license = 'Apache'

--- a/lib/gl_exception_notifier.rb
+++ b/lib/gl_exception_notifier.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'sentry-ruby'
+
 class GLExceptionNotifier
   CONTEXT_TYPES = %i[extra_context tags_context user_context].freeze
 

--- a/spec/gl_exception_notifier_spec.rb
+++ b/spec/gl_exception_notifier_spec.rb
@@ -1,4 +1,3 @@
-require 'sentry-ruby'
 require 'gl_exception_notifier'
 require 'active_support/all'
 


### PR DESCRIPTION
Require sentry-ruby in the gem lib file so it doesn't need to be required in other gems this is used by.