### PR TITLE
Fix rubocop_rules.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,7 @@ config/master.key
 /vendor/bundle
 
 # for a library or gem, you might want to ignore these files since the code is
-# intended to run in multiple environments; otherwise, check them in:
+# intended to run in multiple environments;
 Gemfile.lock
 .ruby-version
 .ruby-gemset

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -57,6 +57,9 @@ RSpec/AnyInstance:
 RSpec/VerifiedDoubles:
   IgnoreSymbolicNames: true
 
+RSpec/StringAsInstanceDoubleConstant:
+  Enabled: false
+
 RSpec/MessageSpies:
   Enabled: false
 

--- a/.rubocop_rules.yml
+++ b/.rubocop_rules.yml
@@ -1,5 +1,5 @@
 ---
-RuboCop-version: 1.65.0 (using Parser 3.3.4.0, rubocop-ast 1.32.0, running on ruby
+RuboCop-version: 1.65.0 (using Parser 3.3.5.1, rubocop-ast 1.34.0, running on ruby
   3.2.5)
 Bundler/DuplicatedGem:
   Severity: warning

--- a/.rubocop_rules.yml
+++ b/.rubocop_rules.yml
@@ -1,6 +1,6 @@
 ---
 RuboCop-version: 1.65.0 (using Parser 3.3.5.1, rubocop-ast 1.34.0, running on ruby
-  3.2.5)
+  3.2.6)
 Bundler/DuplicatedGem:
   Severity: warning
   VersionAdded: '0.46'


### PR DESCRIPTION
`main` currently shows that it failed tests because of a dumb lint issue, this fixes it

This won't require a gem release, it's just a formatting fix.